### PR TITLE
Preserve `imageOpacity` when assigning to `Wheel.items`

### DIFF
--- a/src/wheel.js
+++ b/src/wheel.js
@@ -1113,6 +1113,7 @@ export class Wheel {
           v.push(new Item(this, {
             backgroundColor: item.backgroundColor,
             image: item.image,
+            imageOpacity: item.imageOpacity,
             imageRadius: item.imageRadius,
             imageRotation: item.imageRotation,
             imageScale: item.imageScale,


### PR DESCRIPTION
The `imageOpacity` property wasn't previously passed through when initializing `Item` objects, so it would be ignored.

One can work around this by setting `imageOpacity` manually, as in the following example, but it seems like this property is simply missing from the setter and should be included with the rest of the fields.

```javascript
var wheel = new Wheel(container, { items })

for (const i in items) {
  wheel.items[i].imageOpacity = items[i].imageOpacity
}
```