### PR TITLE
Add font-weight attribute for item label font

### DIFF
--- a/examples/playground/index.html
+++ b/examples/playground/index.html
@@ -30,6 +30,7 @@
       <div class="input-group" data-name="itemLabelBaselineOffset" data-type="range" data-min="-50" data-max="50" data-multiplier="0.01"></div>
       <div class="input-group" data-name="itemLabelColors" data-type="textboxArray"></div>
       <div class="input-group" data-name="itemLabelFont" data-type="textbox"></div>
+      <div class="input-group" data-name="itemLabelFontWeight" data-type="textbox"></div>
       <div class="input-group" data-name="itemLabelFontSizeMax" data-type="range" data-min="10" data-max="150"></div>
       <div class="input-group" data-name="itemLabelRadius" data-type="range" data-min="0" data-max="100" data-multiplier="0.01"></div>
       <div class="input-group" data-name="itemLabelRadiusMax" data-type="range" data-min="0" data-max="100" data-multiplier="0.01"></div>

--- a/src/constants.js
+++ b/src/constants.js
@@ -37,6 +37,7 @@ export const Defaults = Object.freeze({
     itemLabelBaselineOffset: 0,
     itemLabelColors: ['#000'],
     itemLabelFont: 'sans-serif',
+    itemLabelFontWeight: '',
     itemLabelFontSizeMax: baseCanvasSize,
     itemLabelRadius: 0.85,
     itemLabelRadiusMax: 0.2,

--- a/src/wheel.js
+++ b/src/wheel.js
@@ -57,6 +57,7 @@ export class Wheel {
     this.itemLabelBaselineOffset = props.itemLabelBaselineOffset;
     this.itemLabelColors = props.itemLabelColors;
     this.itemLabelFont = props.itemLabelFont;
+    this.itemLabelFontWeight = props.itemLabelFontWeight;
     this.itemLabelFontSizeMax = props.itemLabelFontSizeMax;
     this.itemLabelRadius = props.itemLabelRadius;
     this.itemLabelRadiusMax = props.itemLabelRadiusMax;
@@ -188,7 +189,7 @@ export class Wheel {
     // Set font:
     ctx.textBaseline = 'middle';
     ctx.textAlign = this.itemLabelAlign;
-    ctx.font = this._itemLabelFontSize + 'px ' + this.itemLabelFont;
+    ctx.font = this.itemLabelFontWeight.concat(' ', this._itemLabelFontSize + 'px ' + this.itemLabelFont).trim();
 
     // Build paths for each item:
     for (const [i, a] of angles.entries()) {
@@ -985,6 +986,25 @@ export class Wheel {
 
     this.resize();
   }
+
+  /**
+   * The [font weight](https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight) to use for all item labels.
+   * Example: `'bold'`.
+   */
+  get itemLabelFontWeight() {
+    return this._itemLabelFontWeight;
+  }
+  set itemLabelFontWeight(val) {
+    this._itemLabelFontWeight = util.setProp({
+      val,
+      isValid: typeof val === 'string',
+      errorMessage: 'Wheel.itemLabelFontWeight must be a string',
+      defaultValue: Defaults.wheel.itemLabelFontWeight,
+    });
+
+    this.resize();
+  }
+
 
   /**
    * The maximum font size (in pixels) for all item labels.

--- a/tests/__snapshots__/item.test.js.snap
+++ b/tests/__snapshots__/item.test.js.snap
@@ -204,6 +204,7 @@ Item {
     "_itemLabelFont": "sans-serif",
     "_itemLabelFontSize": 500,
     "_itemLabelFontSizeMax": 500,
+    "_itemLabelFontWeight": "",
     "_itemLabelRadius": 0.85,
     "_itemLabelRadiusMax": 0.2,
     "_itemLabelRotation": 0,

--- a/tests/__snapshots__/wheel.test.js.snap
+++ b/tests/__snapshots__/wheel.test.js.snap
@@ -193,6 +193,7 @@ Wheel {
   "_itemLabelFont": "sans-serif",
   "_itemLabelFontSize": 500,
   "_itemLabelFontSizeMax": 500,
+  "_itemLabelFontWeight": "",
   "_itemLabelRadius": 0.85,
   "_itemLabelRadiusMax": 0.2,
   "_itemLabelRotation": 0,


### PR DESCRIPTION
This pull request introduces the `itemLabelFontWeight` property to the `Wheel` class, allowing users to specify the font weight for item labels.

### Enhancements to `Wheel` class:

* [`src/wheel.js`](diffhunk://#diff-0ef246bc2fd29a0b1564c1ba0f2d27fa4a64e9d2547a3f58dc88dc9d9a9a3a9fR60): Added `itemLabelFontWeight` property, including getter and setter methods, and updated the `ctx.font` assignment to incorporate the new property. [[1]](diffhunk://#diff-0ef246bc2fd29a0b1564c1ba0f2d27fa4a64e9d2547a3f58dc88dc9d9a9a3a9fR60) [[2]](diffhunk://#diff-0ef246bc2fd29a0b1564c1ba0f2d27fa4a64e9d2547a3f58dc88dc9d9a9a3a9fL191-R192) [[3]](diffhunk://#diff-0ef246bc2fd29a0b1564c1ba0f2d27fa4a64e9d2547a3f58dc88dc9d9a9a3a9fR990-R1008)

### Updates to default constants:

* [`src/constants.js`](diffhunk://#diff-8e3b187293d8e7902d08eff3c650466860fe527b0c7da8ec32c1ee4a450f97c5R40): Added `itemLabelFontWeight` to the `Defaults` object with an initial value of an empty string.

### Playground updates:

* [`examples/playground/index.html`](diffhunk://#diff-ec88f37dea5101554845914ce04d122c4b85d1087c4a9f4b24b46a5e5d476702R33): Added a new input group for `itemLabelFontWeight`.

## Evidences


https://github.com/user-attachments/assets/0e2093e9-de6f-4fd0-982b-fb30d9ef2e06

